### PR TITLE
[BUG]: Update downloadservers to comment out configserver

### DIFF
--- a/src/official/downloadservers
+++ b/src/official/downloadservers
@@ -1,2 +1,3 @@
-download.configserver.com
-download2.configserver.com
+# ConfigServer has closed down and download servers no longer active.
+#download.configserver.com
+#download2.configserver.com


### PR DESCRIPTION
As ConfigServer has ceased operations, disabling the download server addresses to ensure that URL hijacking doesn't effect future updates.

# Pull Request
<small>Select which topic best describes your contribution:</small>

- [ ] Feature
- [X] Bug
- [ ] Documentation / Wiki

---

<!---------------------------------------------------------------------->
<br /> Remove access to configserver domain
<!---------------------------------------------------------------------->


### Description
<small>Explain here what your pull request includes and what you've done</small>


<!---------------------------------------------------------------------->
<br />
Commented out the download servers so users do not try to pull from the configserver TLD
---

<br />
<!---------------------------------------------------------------------->

### Before You Submit
<small>Please ensure you check the following items to indicate that you've read this section and completed each task</small>

- [X] My code follows the [Contribution Guidelines](https://github.com/Aetherinox/opengist-debian/blob/main/CONTRIBUTING.md)
- [X] I give expressed consent for my work to be used in this repo
- [X] I have tested my work and it functions as intended
- [X] I have included documentation if the change requires such
