### PR TITLE
Add shellcheck directive to protect.sh

### DIFF
--- a/extras/scripts/protect.sh
+++ b/extras/scripts/protect.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+# shellcheck shell=sh
 # #
 #   ConfigServer Firewall - protect.sh
 #


### PR DESCRIPTION
The repository’s automated check  thinks that protect.sh file is JavaScript, not a POSIX shell script.
So i added # shellcheck shell=sh to let it know. 