### PR TITLE
PR 100: [DOCS] Change blocklist URLs to new domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -589,8 +589,8 @@ By leveraging blocklists, CSF empowers users to proactively defend their infrast
 CSF hosts our own set of blocklists which are are automatically updated every `12 hours`. You may add these sets to your ConfigServer Firewall `/etc/csf/csf.blocklists` with the following new lines:
 
 ```
-CSF_MASTER|43200|400000|https://raw.githubusercontent.com/Aetherinox/csf-firewall/main/blocklists/master.ipset
-CSF_HIGHRISK|43200|0|https://raw.githubusercontent.com/Aetherinox/csf-firewall/main/blocklists/highrisk.ipset
+CSF_MASTER|43200|400000|https://blocklist.configserver.dev/master.ipset
+CSF_HIGHRISK|43200|0|https://blocklist.configserver.dev/highrisk.ipset
 ```
 
 <br />


### PR DESCRIPTION
Updated blocklist URLs in README for CSF.

# Pull Request
<small>Select which topic best describes your contribution:</small>

- [ ] Feature
- [ ] Bug
- [X] Documentation / Wiki

---

<!---------------------------------------------------------------------->
<br />
<!---------------------------------------------------------------------->


### Description
Correct URL for the master.ipset and highrisk.ipset is https://blocklist.configserver.dev/master.ipset,
not https://raw.githubusercontent.com/Aetherinox/csf-firewall/main/blocklists/master.ipset


<!---------------------------------------------------------------------->
<br />

---

<br />
<!---------------------------------------------------------------------->

### Before You Submit
<small>Please ensure you check the following items to indicate that you've read this section and completed each task</small>

- [x] My code follows the [Contributor Guidelines](https://github.com/Aetherinox/csf-firewall/blob/main/CONTRIBUTING.md)
- [x] I give expressed consent for my work to be used in this repo
- [x] I have tested my work and it functions as intended
- [x] I have included docs, if the change requires such; which will be pushed to [https://docs.configserver.dev](https://docs.configserver.dev)
